### PR TITLE
Remove read more

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -94,11 +94,6 @@ get_header();
 						<?php the_excerpt(); ?>
 					</div> <!-- media-content -->
 					<?php if ( ! is_single( $post ) ) { ?>
-					<p>
-						<a class="btn btn-small primary-read-more" href="<?php the_permalink(); ?>">
-							Read More <i class="icon-chevron-right"></i>
-						</a>
-					</p>
 					<?php } ?>
 				</div> <!-- media-body -->
 			</div> <!-- media -->

--- a/functions.php
+++ b/functions.php
@@ -529,13 +529,13 @@ add_action('admin_menu', 'remove_menu_items');
 /*
  * Change excerpt_more function output
  */
-function custom_excerpt_more( $more ) {
-	return '<p><a class="btn btn-small primary-read-more" href="' .
-		get_permalink( get_the_ID() ) .
-		'">Read More <i class="icon-chevron-right"></i></a></p>'
-	;
-}
-add_filter( 'excerpt_more', 'custom_excerpt_more' );
+// function custom_excerpt_more( $more ) {
+// 	return '<p><a class="btn btn-small primary-read-more" href="' .
+// 		get_permalink( get_the_ID() ) .
+// 		'">Read More <i class="icon-chevron-right"></i></a></p>'
+// 	;
+// }
+// add_filter( 'excerpt_more', 'custom_excerpt_more' );
 
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -529,13 +529,10 @@ add_action('admin_menu', 'remove_menu_items');
 /*
  * Change excerpt_more function output
  */
-// function custom_excerpt_more( $more ) {
-// 	return '<p><a class="btn btn-small primary-read-more" href="' .
-// 		get_permalink( get_the_ID() ) .
-// 		'">Read More <i class="icon-chevron-right"></i></a></p>'
-// 	;
-// }
-// add_filter( 'excerpt_more', 'custom_excerpt_more' );
+function custom_excerpt_more( $more ) {
+	return ''; // Remove read-more button
+}
+add_filter( 'excerpt_more', 'custom_excerpt_more' );
 
 
 /**

--- a/single.php
+++ b/single.php
@@ -54,10 +54,6 @@ if ( has_post_format( 'quote' )) {
         <?php
 		} else {
 		?> 
-           <p> <a class="btn btn-small primary-read-more" href="<?php the_permalink(); ?>">
-                Read More <i class="icon-chevron-right"></i>
-            </a>
-            </p>
         <?php	
 			
 		}

--- a/single.php
+++ b/single.php
@@ -47,17 +47,6 @@ if ( has_post_format( 'quote' )) {
 		<p><small><?php the_time('F j, Y'); ?> - <?php the_time('g:i a'); ?></small></p>
 			<?php the_content(); ?>
 		</div><!-- media-content -->
-	    <?php 
-		if (is_single($post)){
-		?> 
-            
-        <?php
-		} else {
-		?> 
-        <?php	
-			
-		}
-		?>
     </div><!-- media-body -->
 </div><!-- media -->
 


### PR DESCRIPTION
### Read More button is no longer rendered on News and Home page

- This improves accessibility by removing redundant links
- The read more link did not have meaningful descriptions
- The article heading remains a link