### PR TITLE
Addded ellipse in place of read more button.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -530,7 +530,7 @@ add_action('admin_menu', 'remove_menu_items');
  * Change excerpt_more function output
  */
 function custom_excerpt_more( $more ) {
-	return ''; // Remove read-more button
+	return ' ...'; // Remove read-more button
 }
 add_filter( 'excerpt_more', 'custom_excerpt_more' );
 


### PR DESCRIPTION
### Now using ellipse in place of read more

- The UI gives a hint that the full article is not yet expanded
- This helps people know that they need to click on the article to expand the text.