### PR TITLE
Fix jquery conflict with unhide-nav.js

### DIFF
--- a/js/unhide-nav.js
+++ b/js/unhide-nav.js
@@ -9,9 +9,11 @@ document.addEventListener('DOMContentLoaded', function() {
         nav.setAttribute('aria-hidden', !navIsHidden);
 
         // Set nav visibility based on navIsHidden
-        if (!navIsHidden) {
+        if (!navIsHidden && !nav.classList.contains('hidden')) {
             // console.log("hiding");
             nav.classList.add('hidden');
+        } else if(!navIsHidden && nav.classList.contains('hidden')) {
+            console.log("state is inconsistent");
         } else {
             // console.log("showing");
             nav.classList.remove('hidden');

--- a/style.css
+++ b/style.css
@@ -1361,6 +1361,12 @@ div.span6 a {
 		display: none;
 	}
 
+
+	/** Override j-query min's weird way of hiding this. **/
+	.nav-collapse.hidden-nav.collapse{
+		height: auto!important;
+	}
+
 	.container .row {
 		padding: 0 1.25em 0 1.25em;
 	}


### PR DESCRIPTION
### JQuery was messing up my show/hide accessibility implementation

- Set height to auto to override how it shows/hides content
- JQuery's show/hide is not accessible since the documents are still visible to AT
- We <3 you JQuery