### PR TITLE
Fix hero past/future links

### DIFF
--- a/style.css
+++ b/style.css
@@ -1515,7 +1515,7 @@ div.span6 a {
 		float: left;
 	}
 
-	.navbar a.btn-navbar:hover {
+	.navbar .btn-navbar:hover, .navbar .btn-navbar:focus {
 		color: #94c83d;
 	}
 

--- a/style.css
+++ b/style.css
@@ -1520,7 +1520,7 @@ div.span6 a {
 	}
 
 	.navbar.top-mobile-nav {
-		margin-bottom: 10px;
+		margin-bottom: 0.625rem;
 	}
 
 	.navbar.top-mobile-nav a {

--- a/style.css
+++ b/style.css
@@ -892,18 +892,34 @@ p.street-address {
     box-shadow: 0rem 0.25rem 0.25rem 0rem rgba(0, 0, 0, 0.2);
 }
 
-#hero-past-future li { 
-	display: inline; 
+ul#hero-past-future {
+	display: flex;
+	flex-direction: row;
+	align-content: center;
+	width: 100%;
+	height: fit-content;
+	list-style-type: none;
+	padding: 0;
 	margin: 0;
 }
 
-#hero-past-future a {
+#hero-past-future li { 
+	flex: 0 1 100%;
+	margin: 0;
+	list-style-type: none;
+	display: inline-flex;
+}
+
+#hero-past-future li a {
+	border: 1px solid black;
 	color: black;
 	background-color: #A8976F;
 	text-decoration: none;
-	display: block;
-	width: 50%;
-	float: left;
+	display: inline-flex;
+  	flex-direction: column-reverse;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
 }
 
 #hero-past-future em {
@@ -933,7 +949,6 @@ p.street-address {
 
 #hero-past-future .inner {
 	display: block;
-	border: 1px solid black;
 }
 
 #hero-future .inner { border-left-width: 0;}

--- a/style.css
+++ b/style.css
@@ -917,7 +917,7 @@ ul#hero-past-future {
 	text-decoration: none;
 	display: inline-flex;
   	flex-direction: column-reverse;
-	justify-content: center;
+	justify-content: left;
 	width: 100%;
 	height: 100%;
 }
@@ -1610,40 +1610,10 @@ div.span6 a {
 
 	#hero-links { margin-top: 0.625rem;}
 
-	/** Make the list items the same height **/
-	#hero-past-future { 
-		margin: 0;
-		box-sizing: content-box;
-		display: inline-block;
-		width: 100%;
-		min-height: fit-content;
-	}
-
-	#hero-past-future .inner {
-		border: none;
-	}
-
-	#hero-past-future a { 
-		max-height: fit-content;
-		width: 100%;
-	}
-	
-	#hero-past-future li { 
-		display: flex;
-		flex-direction: column;
-		border: 1px solid black;
-	}
-
-	li#hero-past, li#hero-future {
-		display: flex;
-		flex: 1;
-		width: 100%;
-	}
-
 }
  
 /* Landscape phones and down */
-@media (max-width: 480px) { 
+@media (max-width: 495px) { 
 
 	div#header-logo {
 		text-align: left;
@@ -1715,6 +1685,19 @@ div.span6 a {
 
 	#bclogo { 
 		margin-left: 0;
+	}
+
+	/** Make the footer of widget display seperately **/
+	ul#hero-past-future {
+		display: block;
+		width: 100%;
+	}
+
+	
+	#hero-past-future li { 
+		display: inline-block;
+		width: 100%;
+		border: 1px solid black;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -1349,8 +1349,8 @@ div.span6 a {
 
 	/* Radio rethink styles */
 
-	#hero-block {
-		height: 16rem;
+	#hero-block, #hero-text {
+		height: 18rem;
 	}
 
 	#hero-text-wrapper,
@@ -1360,7 +1360,6 @@ div.span6 a {
 	}
 
 	#hero-text {
-		height: 16rem;
 		width: 29.75rem;
 	}
 

--- a/style.css
+++ b/style.css
@@ -1378,37 +1378,6 @@ div.span6 a {
 	}
 
 	#hero-links { margin-top: 0;}
-
-	/** Make the radio rethink footer the same height **/
-	#hero-past-future { 
-		margin: 0;
-		box-sizing: content-box;
-		display: inline-block;
-		width: 100%;
-		min-height: fit-content;
-	}
-
-	#hero-past-future .inner {
-		border: none;
-	}
-
-	#hero-past-future a { 
-		max-height: fit-content;
-		width: 100%;
-	}
-	
-	#hero-past-future li { 
-		display: flex;
-		flex-direction: column;
-		border: 1px solid black;
-	}
-
-	li#hero-past, li#hero-future {
-		display: flex;
-		flex: 1;
-		width: 100%;
-	}
-
 }
 
 /* Landscape phone to portrait tablet */

--- a/style.css
+++ b/style.css
@@ -1693,7 +1693,6 @@ div.span6 a {
 		width: 100%;
 	}
 
-	
 	#hero-past-future li { 
 		display: inline-block;
 		width: 100%;

--- a/style.css
+++ b/style.css
@@ -1697,7 +1697,6 @@ div.span6 a {
 	#hero-past-future li { 
 		display: inline-block;
 		width: 100%;
-		border: 1px solid black;
 	}
 }
 


### PR DESCRIPTION
### Radio Rethink Past/Future Links were displaying weird when Roots Rock and Soul starts

- In tablet view this would cause the layout to break as such:
<img width="1061" alt="Screenshot 2024-12-06 at 2 54 15 PM" src="https://github.com/user-attachments/assets/e9f6ebb3-3273-4bc3-8ac5-88ca0bcf4c7f">

- Now thanks to flexbox styles, it displays like this
<img width="1061" alt="Screenshot 2024-12-06 at 2 54 26 PM" src="https://github.com/user-attachments/assets/c02bada4-87c1-408a-8d71-e1a3857f8bd3">

### Radio Rethink past/future links now display as their own rows on mobile

- This solves an issue where the text would start flowing around the box it should go in

- Broken layout
<img width="440" alt="Screenshot 2024-12-06 at 2 58 31 PM" src="https://github.com/user-attachments/assets/93fe94ea-0891-427d-b5ac-75eb7c711e89">

- Fixed layout
<img width="440" alt="Screenshot 2024-12-06 at 2 58 52 PM" src="https://github.com/user-attachments/assets/bf392097-de6b-435b-afac-4087e9651403">
