### PR TITLE
Fix footer and ensure RWD is followed on mobile

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -3,12 +3,10 @@
 </div><!-- wrapper container -->
 
 		<footer class="container" id="foot">
-			<nav aria-label="Connect with KBCS" class="row">
+			<nav aria-label="Connect with KBCS">
 
-				<div class="span3">
-                	
-                     <div class="vcard">
-                         <div class="org"><h4><a class="url fn n" href="<?php echo home_url(); ?>/">KBCS Radio</a></h4></div>
+				<div class="span3 vcard">
+                         <h4><a class="url fn n org" href="<?php echo home_url(); ?>/">KBCS Radio</a></h4>
                          
                          <address class="adr">
                               <p class="street-address">3000 Landerholm Circle SE</p>
@@ -19,7 +17,6 @@
                             <li><a href="<?php echo home_url(); ?>/about/contact/"><strong>Contact Us</strong></a></li>
                             <li><a href="<?php echo home_url(); ?>/about/directions/"><strong>Map &amp; directions</strong></a></li>
                         </ul>
-                   </div><!-- .vcard -->
 				</div><!-- span3 -->
                 
                 <div class="span3">
@@ -29,14 +26,9 @@
 					<li><a href="mailto:dj@kbcs.fm">dj@kbcs.fm</a></li>
 					<li>425-564-2424</li>
 					</ul>
-                    
-                    
-					<h4>Listener comments</h4>
-					<ul>
-                    <li><a href="mailto:listenercomment@kbcs.fm">listenercomment@kbcs.fm</a></li>
-                    </ul>
-                   
-					
+				</div><!-- span3 -->
+
+				<div class="span3">
 					<h4>News Department</h4>
                     <ul>
 					<li><a href="mailto:dj@kbcs.fm">news@kbcs.fm</a></li>
@@ -53,6 +45,9 @@
 						<li><a href="<?php echo home_url(); ?>/support/volunteer/">Volunteer</a></li>
 						<li><a href="<?php echo home_url(); ?>/support/">Support Us</a></li>
 					</ul>
+				</div><!-- span3 -->
+
+				<div class="span3">
 					<h4>Legal</h4>
 					<ul>
                         <li><a href="<?php echo home_url(); ?>/kbcs-public-files/">KBCS Public Files</a></li>
@@ -60,16 +55,21 @@
 						<li><a href="https://www.bellevuecollege.edu/events/trustees/">Board Meetings</a></li>
 					</ul>
 				</div><!-- span3 -->
-	
-	
-				<div class="span3 bc-footer">
-                    <div id="bclogo">
-                	
-                	<p class="bc-service">91.3 KBCS is a public service at</p>
-                    <a href="https://www.bellevuecollege.edu"><img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College" /></a></div> <!--bclogo-->
-   
-				</div><!-- span3 -->
+
+				<div class="span3">
+					<h4>Listener comments</h4>
+					<ul>
+                    <li><a href="mailto:listenercomment@kbcs.fm">listenercomment@kbcs.fm</a></li>
+                    </ul>
+                </div><!-- span3 -->
 			</nav><!-- row -->
+
+			<div id="bclogo" class="span9">
+                	<p class="bc-service">91.3 KBCS is a public service at</p>
+                    <a href="https://www.bellevuecollege.edu">
+						<img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College" />
+					</a>
+			</div> <!--bclogo-->
 		
 		</footer><!-- footer .container -->
 

--- a/page.php
+++ b/page.php
@@ -2,7 +2,7 @@
 <div class="whatpageisthis">page.php</div>
 
 <div class="row">
-	<h1 class="title"><?php the_title();?></h1>
+	<h1><?php the_title();?></h1>
 	<main class="span8" id="content">
 		<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 

--- a/style.css
+++ b/style.css
@@ -56,7 +56,7 @@ div.aligncenter {
     margin: 5px auto 5px auto;
 }
 
-a img.alignright {
+img.alignright {
     float: right;
     margin: 5px 0 20px 20px;
 	max-height: 6em;
@@ -171,6 +171,10 @@ h2.staff-title {
 h1, h2, h3, h4, h5, h6 {
 	font-family: 'Arvo', Georgia, "Times New Roman", Times, serif;
 	font-weight: normal;
+}
+
+h1 {
+  margin: 0em 1rem;
 }
 
 h2 {
@@ -1457,6 +1461,9 @@ div.span6 a {
 		margin-bottom: 0;
 	}
 	
+	.sidebar{
+		margin-top: 1.75rem;
+	}
 
 	.global-search {
 		float: none;
@@ -1630,7 +1637,7 @@ div.span6 a {
 /* Landscape phones and down */
 @media (max-width: 495px) { 
 
-	div#header-logo {
+	#header-logo {
 		text-align: left;
 		float: left;
 		margin-right: 1.25rem;
@@ -1698,8 +1705,34 @@ div.span6 a {
 	padding: 0.3125rem 0;
 	}
 
-	#bclogo { 
-		margin-left: 0;
+	img.alignright {
+		float: none;
+		margin: 5px 0 20px 20px;
+		max-height: auto;
+		max-width: 100%;
+	}
+
+	.media {
+		display: block;
+	}
+
+	.media-left {
+		float: none;
+		max-height: fit-content;
+		max-width: 100%;
+		margin: 0 0 1.25rem 0;
+	}
+
+	.media-left img {
+		width: 100% !important;
+    	height: auto !important;
+		max-width: 100%!important;
+		max-height: fit-content!important;
+	}
+
+	.featured-caption {
+		max-width: 100%;
+		font-size: 0.875em;
 	}
 
 	/** Make the footer of widget display seperately **/

--- a/style.css
+++ b/style.css
@@ -689,18 +689,28 @@ img.alignright {
 
 /*Footer*/
 #foot {
+	display: grid;
+	justify-content: space-evenly;
+	align-items: center;
+	row-gap: 1.25rem;
 	border-top: 1px dashed #ddd;
 	margin-top: 5rem;
 	padding-bottom: 12.5rem;
 }
 
-#foot .bc-service {
-	font-size: 1em;
-	padding-left: 2.375rem;
+#foot .span3 {
+	margin: 0;
 }
 
-#foot #bclogo { 
-	margin-left: -6.25rem;
+#foot p.bc-service {
+	font-size: 1em;
+	line-height: 1.5em;
+	/* padding-left: 2.375rem; */
+	margin-bottom: 0;
+}
+
+#bclogo { 
+	display: block;
     padding-top: 0.938rem;
     text-align: center;
 }
@@ -1289,6 +1299,11 @@ div.span6 a {
 	.donateButton a {
 		font-size: 1.5em;
 		border-radius: 0.875rem;
+	}
+
+	/** Footer styling **/
+	#foot.container {
+		width: 1170px;
 	}
 	
 }


### PR DESCRIPTION
### Footer now uses `display: grid` to render

- This ensures the footer looks good on all screen sizes
- Decided to make BC logo at the end of the footer as a `span9`

### Thumbnail images on mobile now take up full size

- This is done to ensure good use of screen space and make text more readable on small devices
- This also ensures people who use screen magnification are able to use the mobile version of the site