### PR TITLE
Now using ARIA-Expanded for unhide-nav.js

### DIFF
--- a/header.php
+++ b/header.php
@@ -116,7 +116,7 @@
 			<div class="navbar top-mobile-nav">
 				<div class="navbar-inner">
                 	<div class="container">
-                        <button class="btn btn-navbar menu" aria-label="Menu" data-toggle="collapse" data-target=".nav-collapse">
+                        <button class="btn btn-navbar menu" aria-label="Menu" aria-controls="nav-main" aria-expanded="false" data-toggle="collapse" data-target=".nav-collapse">
                         	<span aria-hidden="true" data-icon="&#xf0c9;"></span>
                         </button>
                         <a class="brand" href="<?php echo esc_url(home_url( '/' ) ); ?>"><img src="<?php bloginfo('template_directory'); ?>/img/kbcs_logo_horiz.png" alt="91.3 KBCS (KBCS Logo)" title="KBCS home page" /></a>
@@ -128,7 +128,7 @@
 						'menu' => 'main-nav',
 						'container_aria_label' => 'Main',
 						'container_class' => 'nav-collapse hidden-nav', 
-						'items_wrap'      => '<nav class="hidden-nav hidden" aria-hidden="true" aria-label="Main"><ul id="%1$s" class="%2$s">%3$s</ul></nav>',
+						'items_wrap'      => '<nav id="nav-main" class="hidden-nav hidden" aria-expanded="false" aria-label="Main"><ul id="%1$s" class="%2$s">%3$s</ul></nav>',
 						'menu_class' => 'nav', 
 						'fallback_cb' => 'wp_page_menu',
 						'menu_id' => 'main-nav'

--- a/js/unhide-nav.js
+++ b/js/unhide-nav.js
@@ -2,21 +2,23 @@
 
 document.addEventListener('DOMContentLoaded', function() {
     const menuButton = document.querySelector('.btn-navbar.menu');
-    const nav = document.querySelector('nav.hidden-nav');
+    const nav = document.getElementById('nav-main');
+    const navClass = document.querySelector('nav.hidden-nav');
 
     menuButton.addEventListener('click', function() {
-        const navIsHidden = nav.getAttribute('aria-hidden') === 'true';
-        nav.setAttribute('aria-hidden', !navIsHidden);
+        const navIsHidden = nav.getAttribute('aria-expanded') === 'false';
+        nav.setAttribute('aria-expanded', !navIsHidden);
+        menuButton.setAttribute('aria-expanded', !navIsHidden);
 
         // Set nav visibility based on navIsHidden
-        if (!navIsHidden && !nav.classList.contains('hidden')) {
-            // console.log("hiding");
-            nav.classList.add('hidden');
-        } else if(!navIsHidden && nav.classList.contains('hidden')) {
+        if (navIsHidden && !nav.classList.contains('hidden')) {
+            console.log("hiding");
+            navClass.classList.add('hidden');
+        } else if(navIsHidden && !nav.classList.contains('hidden')) {
             console.log("state is inconsistent");
         } else {
-            // console.log("showing");
-            nav.classList.remove('hidden');
+            console.log("showing");
+            navClass.classList.remove('hidden');
         }
     });
 });


### PR DESCRIPTION
### Now using [ARIA-Expanded](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) to hide/unhide nav

- This suggestion was made by Taija on a pull request
- This is more accurate than using an aria-hidden attribute to store the state of the nav.
- This is also more accessible to assistive technology.