### PR TITLE
Fix footer bugs

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -62,9 +62,9 @@
                     <li><a href="mailto:listenercomment@kbcs.fm">listenercomment@kbcs.fm</a></li>
                     </ul>
                 </div><!-- span3 -->
-			</nav><!-- row -->
+			</nav>
 
-			<div id="bclogo" class="span9">
+			<div id="bclogo" class="span">
                 	<p class="bc-service">91.3 KBCS is a public service at</p>
                     <a href="https://www.bellevuecollege.edu">
 						<img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College" />

--- a/style.css
+++ b/style.css
@@ -705,7 +705,7 @@ img.alignright {
 footer#foot.container nav {
 	display: flex;
   	flex-wrap: wrap;
-	justify-content: center;
+	justify-content: left;
 	align-items: flex-start;
 }
 
@@ -1266,6 +1266,10 @@ div.span6 a {
 /* Large desktop overides */
 @media (min-width: 1200px) {
 
+	footer#foot.container nav .span3 {
+		width: 20%;
+	}
+
 	h1.title{
 		margin: 0rem 0rem 1rem 1.875rem;
 	}
@@ -1316,7 +1320,7 @@ div.span6 a {
 
 	/** Footer styling **/
 	#foot.container {
-		width: 1170px;
+		width: 73.125rem;
 	}
 	
 }
@@ -1336,8 +1340,14 @@ div.span6 a {
 	}
 
 	/* Footer styling */
+	/** Footer **/
+	footer#foot.container nav {
+		display: inline-flex;
+		justify-content: left;
+	}
+
 	footer#foot.container nav .span3 {
-		width: 18.75rem;
+		width: 33%;
 	}
 	
 	/* Misc */
@@ -1412,14 +1422,13 @@ div.span6 a {
 	/** Footer **/
 	footer#foot.container nav {
 		display: inline-flex;
-		justify-content: center;
-		
+		padding: 0 1rem;	
 	}
 
 	footer#foot.container nav .span3 {
 		margin: 0;
 		padding: 0;
-		width: 12.8rem;
+		width: 33%;
 	}
 
 	/** Override j-query min's weird way of hiding this. **/
@@ -1645,10 +1654,34 @@ div.span6 a {
 	#hero-links { margin-top: 0.625rem;}
 
 }
+
+/* Landscape phone to portrait tablet */
+@media (max-width: 676px) { 
+
+	footer#foot.container nav .span3 {
+		width: 50%;
+	}
+}
  
 /* Landscape phones and down */
 @media (max-width: 495px) { 
 
+	/** Footer **/
+	#foot {
+		display: block;
+		padding-bottom: 9rem;
+	}
+
+	footer#foot.container nav {
+		display: block;	
+	}
+
+	footer#foot.container nav .span3, footer#foot.container #bclogo.span {
+		margin: 0;
+		width: 100%;
+	}
+
+	/** Header **/
 	#header-logo {
 		text-align: left;
 		float: left;
@@ -1756,24 +1789,6 @@ div.span6 a {
 	#hero-past-future li { 
 		display: inline-block;
 		width: 100%;
-	}
-
-	/** Footer **/
-	#foot {
-		padding-bottom: 6rem;
-	}
-
-	footer#foot.container nav {
-		display: block;
-		/* justify-content: center; */
-		
-	}
-
-	footer#foot.container nav .span3, footer#foot.container #bclogo.span {
-		margin: 0;
-		/* padding: 0 0 0 1.25rem; */
-		width: 80vw;
-		max-width: 14rem;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -702,6 +702,13 @@ img.alignright {
 	padding-bottom: 12.5rem;
 }
 
+footer#foot.container nav {
+	display: flex;
+  	flex-wrap: wrap;
+	justify-content: center;
+	align-items: flex-start;
+}
+
 #foot .span3 {
 	margin: 0;
 }
@@ -713,10 +720,12 @@ img.alignright {
 	margin-bottom: 0;
 }
 
-#bclogo { 
+#bclogo.span { 
 	display: block;
     padding-top: 0.938rem;
+	margin: 0;
     text-align: center;
+	width: 100%;
 }
 
 #foot h4 {
@@ -1327,18 +1336,8 @@ div.span6 a {
 	}
 
 	/* Footer styling */
-	#foot .span3{
-		margin-left: 0rem;
-		/* Override bootstrap width */
-		width: 12.5rem;
-	}
-
-	#foot .span3 #bclogo { 
-		margin-left: -1.25rem;
-	}
-
-	#foot .bc-footer {
-		width: 8.75rem;
+	footer#foot.container nav .span3 {
+		width: 18.75rem;
 	}
 	
 	/* Misc */
@@ -1410,12 +1409,25 @@ div.span6 a {
 		margin: 0em 0em 1rem 0;
 	}
 
+	/** Footer **/
+	footer#foot.container nav {
+		display: inline-flex;
+		justify-content: center;
+		
+	}
+
+	footer#foot.container nav .span3 {
+		margin: 0;
+		padding: 0;
+		width: 12.8rem;
+	}
+
+	/** Override j-query min's weird way of hiding this. **/
 	nav.hidden {
 		display: none;
 	}
 
 
-	/** Override j-query min's weird way of hiding this. **/
 	.nav-collapse.hidden-nav.collapse{
 		height: auto!important;
 	}
@@ -1744,6 +1756,24 @@ div.span6 a {
 	#hero-past-future li { 
 		display: inline-block;
 		width: 100%;
+	}
+
+	/** Footer **/
+	#foot {
+		padding-bottom: 6rem;
+	}
+
+	footer#foot.container nav {
+		display: block;
+		/* justify-content: center; */
+		
+	}
+
+	footer#foot.container nav .span3, footer#foot.container #bclogo.span {
+		margin: 0;
+		/* padding: 0 0 0 1.25rem; */
+		width: 80vw;
+		max-width: 14rem;
 	}
 }
 


### PR DESCRIPTION
### Footer now renders properly at all screen sizes

- I accomplished this by making the `<nav>` element `display:flex` or `display:inline-flex` then making the width of each element relative to the parent container width using percentages.
- The BC-logo is now centered on all pages by having no padding/margins and being justified center, additionally it is now a `span` class instead of a `span9`.