### PR TITLE
Fix single program page issues

### DIFF
--- a/single-programs.php
+++ b/single-programs.php
@@ -64,7 +64,7 @@ $audio_content = json_encode($output);
 <div class="container">
 		<div class="row">
 			<main class="span8" id="content">
-			<div id="hero-block">
+			<div class='programs-hero' id="hero-block">
 
 				<div class="row-fluid"  id="hero-text-wrapper">
 					 <div class="span9" id="hero-text">
@@ -95,9 +95,16 @@ $audio_content = json_encode($output);
 						}
 						?>
 						
-						<p class="program-days-times">
-							<?php echo Homepage_Program::get_airtimes_for_display( $post->ID ); ?>
-						</p>
+							<div class="program-days-times">
+								<?php 
+								$airtimes = Homepage_Program::get_airtimes_for_display($post->ID);
+								// Split on commas that are followed by a day of the week
+								$times = preg_split('/(?<=(?:am|pm)),\s*(?=[A-Za-z]+day)/', $airtimes);
+								foreach ($times as $time) {
+									echo '<p>' . trim($time) . '</p>';
+								}
+								?>
+							</div>
 						</div><!-- .inner -->
 					</div> <!-- hero-text -->
 

--- a/style.css
+++ b/style.css
@@ -1143,6 +1143,16 @@ text-align: center;
 	margin-top: 0;
 	font-weight: bold;
 }
+
+/* Reflowed single program hero */
+#hero-block.programs-hero #hero-text-wrapper.row-fluid h1 {
+	margin-left: 0;
+	margin-bottom: 0.25rem;
+}
+
+#hero-block.programs-hero #hero-text-wrapper.row-fluid p {
+	margin-bottom: 0.5rem;
+}
 	
 /* Post formats */
 
@@ -1354,6 +1364,10 @@ div.span6 a {
 	#hero-text p {
 		font-size: 1.0625em;
 		line-height: 1.875em;
+	}
+
+	#hero-block.programs-hero #hero-text-wrapper.row-fluid h1 {
+		line-height: normal;
 	}
 
 	#error404-goodnews h1 {


### PR DESCRIPTION
### Single Programs Page Rendering Issues Addressed:

![Screenshot from 2025-04-24 13-34-05](https://github.com/user-attachments/assets/559c9e1a-f5bd-48ce-ac48-35b648c277d8)

- Incorrect indentation of `h1` tag in `#hero-block` on single program pages
- Multiple showtimes being coerced into a single `p` tag and rendered as one chunk of text
- Style issues on larger screens were the line height of the heading line height is disruptive

### Methods

- Creating a regular expression in single program page that splits showtimes by am or pm followed by a comma
- Adding styles that will reduce the margin on the bottom of paragraphs to prevent overflow for shows with many runtimes such as KBCS Jukebox
- Creating a new class for single program page hero-block content to distinguish these styles from main page hero-block styles
- Using Polypane to test a variety of other screen sizes to ensure that no layout changes are broken by new styles

### Results

![Screenshot from 2025-04-24 13-33-45](https://github.com/user-attachments/assets/33258438-afca-40c7-8cda-b3fea9c8f803)

- Layout follows style conventions for other parts of the website
- Multiple showtimes are now rendered on separate lines, with new paragraph groupings to improve accessibility to screen magnifiers and screen readers
- Changes do not affect other site pages due to specificity of styles introduced.