### PR TITLE
Resolved semantic issue on staff page

### DIFF
--- a/template-staff-directory.php
+++ b/template-staff-directory.php
@@ -57,7 +57,7 @@ get_header(); ?>
 									    	
 									    	<div class="media-body">
 			
-				    							<a href="<?php the_permalink(); ?>"><h2 class="media-heading"><?php the_title(); ?></h2></a>
+				    							<h2 class="media-heading"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 
 												<?php
 													if(get_post_meta($post->ID, 'staff_role', true !='')) {
@@ -129,7 +129,7 @@ get_header(); ?>
 									    	
 									    	<div class="media-body">
 			
-				    							<a href="<?php the_permalink(); ?>"><h2 class="media-heading"><?php the_title(); ?></h2></a>
+											<h2 class="media-heading"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 
 
 												<?php
@@ -217,7 +217,7 @@ get_header(); ?>
 									    	
 									    	<div class="media-body">
 			
-				    							<a href="<?php the_permalink(); ?>"><h2 class="media-heading"><?php the_title(); ?></h2></a>
+												<h2 class="media-heading"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 
 												<?php
 													if(get_post_meta($post->ID, 'staff_role', true !='')) {


### PR DESCRIPTION
### Semantic Issue on Staff page:

- Links are outside of `h2` tags instead of inside of `h2` tags
- Nesting order is important for both screen reader users and visual rendering of the page
- Resolved this issue by modifying the PHP rendering template for each of the 3 panes

### Possible future improvements:

- Reuse the rendering code by writing a singular function that accepts an argument of the current tab selected
- `template-staff-directory.php` uses the same code structure in three places, this is not very readable for developers