### PR TITLE
Created new template nav for listen page.

### DIFF
--- a/template-nav-listen.php
+++ b/template-nav-listen.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Template Name: Listen Navigation Page
+ *
+ *
+ * Learn more: http://codex.wordpress.org/Template_Hierarchy
+ *
+ */
+get_header(); ?>
+<div class="whatpageisthis">template-nav-listen.php</div>
+
+<div class="row">
+	<main class="span8" id="content">
+	<h1 class="inner-heading"><?php the_title(); ?></h1>
+	<?php
+
+    $args = [
+      "post_type" => "page",
+      "posts_per_page" => -1,
+      "orderby" => "menu_order title",
+      "post_status" => "publish",
+      "post_parent" => $post->ID,
+      ];
+    $loop = new WP_Query($args);
+    while ($loop->have_posts()):
+        $loop->the_post(); ?>
+            <section class="nav-section">
+               	<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                <?php
+                the_excerpt();
+                edit_post_link("edit", "<small>", "</small>");
+                ?>
+    		</section>
+            <?php
+    endwhile;
+    wp_reset_query();
+
+    while (have_posts()):
+        the_post();
+    	the_content();
+    endwhile;
+
+  ?>
+
+
+    </main><!-- span8  #content -->
+
+	<?php get_sidebar();
+// sidebar 1
+?>
+
+</div><!-- row -->
+
+
+<?php get_footer(); ?>


### PR DESCRIPTION
### Created a new nav template for listen page

This nav template reverses the post data to go on the bottom of the page instead of the top. This is important since we will be putting the reception tips below the various ways to listen online.

Note: This will require modifications to the WordPress content and we will need to setup a redirect from the FAQ page to the listen page.

### This is what it will look like

<img width="957" height="812" alt="Screenshot from 2025-07-22 11-15-23" src="https://github.com/user-attachments/assets/20a299cc-34f6-4cec-bea5-187678f28f37" />
